### PR TITLE
sequencial → sequential

### DIFF
--- a/caterva/caterva_ext.pyx
+++ b/caterva/caterva_ext.pyx
@@ -130,7 +130,7 @@ cdef extern from "caterva.h":
     ctypedef struct caterva_storage_t:
         int32_t chunkshape[CATERVA_MAX_DIM]
         int32_t blockshape[CATERVA_MAX_DIM]
-        bool sequencial
+        bool sequential
         char* urlpath
         caterva_metalayer_t metalayers[CATERVA_MAX_METALAYERS]
         int32_t nmetalayers
@@ -281,7 +281,7 @@ cdef create_caterva_storage(caterva_storage_t *storage, kwargs):
         storage.urlpath = urlpath
     else:
         storage.urlpath = NULL
-    storage.sequencial = sequential
+    storage.sequential = sequential
     for i in range(len(chunks)):
         storage.chunkshape[i] = chunks[i]
         storage.blockshape[i] = blocks[i]

--- a/examples/ex_persistency.py
+++ b/examples/ex_persistency.py
@@ -29,7 +29,7 @@ nparray = np.arange(int(np.prod(shape)), dtype=dtype).reshape(shape)
 
 # Create a caterva array from a numpy array (on disk)
 a = cat.from_buffer(bytes(nparray), nparray.shape, itemsize, chunks=chunks, blocks=blocks,
-                    urlpath=urlpath, sequencial=False)
+                    urlpath=urlpath, sequential=False)
 
 # Read a caterva array from disk
 b = cat.open(urlpath)

--- a/tests/test_metalayers.py
+++ b/tests/test_metalayers.py
@@ -13,7 +13,7 @@ import os
 from msgpack import packb
 
 
-@pytest.mark.parametrize("sequencial",
+@pytest.mark.parametrize("sequential",
                          [
                              True,
                              False,
@@ -24,7 +24,7 @@ from msgpack import packb
                              ([20, 134, 13], [12, 66, 8], [3, 13, 5], "testmeta01.cat", np.int32),
                              ([12, 13, 14, 15, 16], [8, 9, 4, 12, 9], [2, 6, 4, 5, 4], "testmeta02.cat", np.float32)
                          ])
-def test_metalayers(shape, chunks, blocks, urlpath, sequencial, dtype):
+def test_metalayers(shape, chunks, blocks, urlpath, sequential, dtype):
     if os.path.exists(urlpath):
         cat.remove(urlpath)
 
@@ -34,7 +34,7 @@ def test_metalayers(shape, chunks, blocks, urlpath, sequencial, dtype):
     # Create an empty caterva array (on disk)
     itemsize = np.dtype(dtype).itemsize
     a = cat.empty(shape, itemsize, chunks=chunks, blocks=blocks,
-                  urlpath=urlpath, sequencial=sequencial,
+                  urlpath=urlpath, sequential=sequential,
                   meta={"numpy": numpy_meta,
                         "test": test_meta})
 

--- a/tests/test_persistency.py
+++ b/tests/test_persistency.py
@@ -12,7 +12,7 @@ import numpy as np
 import os
 
 
-@pytest.mark.parametrize("sequencial",
+@pytest.mark.parametrize("sequential",
                          [
                              True,
                              False,
@@ -23,14 +23,14 @@ import os
                              ([20, 134, 13], [7, 22, 5], [3, 5, 3], "test01.cat", np.int32),
                              ([12, 13, 14, 15, 16], [4, 6, 4, 7, 5], [2, 4, 2, 3, 3], "test02.cat", np.float32)
                          ])
-def test_persistency(shape, chunks, blocks, urlpath, sequencial, dtype):
+def test_persistency(shape, chunks, blocks, urlpath, sequential, dtype):
     if os.path.exists(urlpath):
         cat.remove(urlpath)
 
     size = int(np.prod(shape))
     nparray = np.arange(size, dtype=dtype).reshape(shape)
     _ = cat.asarray(nparray, chunks=chunks, blocks=blocks,
-                    urlpath=urlpath, sequencial=sequencial)
+                    urlpath=urlpath, sequential=sequential)
     b = cat.open(urlpath)
 
     bc = b[:]


### PR DESCRIPTION
Same as https://github.com/Blosc/caterva/pull/91.

Again, not sure if there is an easy way to keep API back-compatibility. Probably easier in Python than C, but then is it worth the effort in Python if it cannot be mitigated in C?